### PR TITLE
Fix item chart displaying empty plot without legend filters

### DIFF
--- a/ItemInterpreter/UI/Charts/ItemCountChart.xaml.cs
+++ b/ItemInterpreter/UI/Charts/ItemCountChart.xaml.cs
@@ -339,9 +339,13 @@ namespace ItemInterpreter.UI.Charts
                 }
             }*/
 
+            var seriesParaExibir = selecionados.Count > 0
+                ? selecionados
+                : _seriesPorItem.Keys.ToList();
+
             PlotModel.Series.Clear();
 
-            foreach (var nome in selecionados)
+            foreach (var nome in seriesParaExibir)
             {
                 if (_seriesPorItem.TryGetValue(nome, out var serieOriginal))
                 {


### PR DESCRIPTION
## Summary
- ensure the item chart keeps all tracked series visible when no legend filters are selected
- reuse the cached series definitions whenever the legend selection list is empty

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cacb8807248332b9051dcaa632032b