### PR TITLE
Implement dashboard enhancements and item history

### DIFF
--- a/ItemInterpreter/Data/ItemSnapshot.cs
+++ b/ItemInterpreter/Data/ItemSnapshot.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace ItemInterpreter.Data
+{
+    public class ItemSnapshot
+    {
+        public DateTime Timestamp { get; set; }
+        public int Section { get; set; }
+        public int Index { get; set; }
+        public string ItemName { get; set; } = string.Empty;
+        public int InventoryCount { get; set; }
+        public int WarehouseCount { get; set; }
+
+        public int TotalCount => InventoryCount + WarehouseCount;
+    }
+}

--- a/ItemInterpreter/Data/TrackedItem.cs
+++ b/ItemInterpreter/Data/TrackedItem.cs
@@ -11,7 +11,26 @@ namespace ItemInterpreter.Data
         public int Section { get; set; }
         public int Index { get; set; }
 
-        // ✅ Adicione esta propriedade
         public string ItemName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Quantidade mínima desejada para manter o estoque saudável.
+        /// </summary>
+        public int? MinimumTarget { get; set; }
+
+        /// <summary>
+        /// Quantidade máxima aceitável antes de sinalizar excesso.
+        /// </summary>
+        public int? MaximumTarget { get; set; }
+
+        /// <summary>
+        /// Preço médio de aquisição do item para cálculos de custo.
+        /// </summary>
+        public decimal? PurchasePrice { get; set; }
+
+        /// <summary>
+        /// Preço médio de venda estimado para o item.
+        /// </summary>
+        public decimal? SalePrice { get; set; }
     }
 }

--- a/ItemInterpreter/Logic/DailyItemTracker.cs
+++ b/ItemInterpreter/Logic/DailyItemTracker.cs
@@ -12,21 +12,11 @@ using Microsoft.Data.SqlClient;
 
 namespace ItemInterpreter.Logic
 {
-    public class ItemTrackingLog
-    {
-        public int Section { get; set; }
-        public int Index { get; set; }
-        public DateTime Date { get; set; }
-        public int Warehouse { get; set; }
-        public int Inventory { get; set; }
-        public string ItemName { get; set; } = string.Empty; // resolvendo CS8618
-    }
-
     public static class DailyItemTracker
     {
         private static readonly string ConnectionString = "Data Source=localhost;Initial Catalog=MuOnline;Integrated Security=True;TrustServerCertificate=True;";
         private static readonly string ConfigPath = "tracked_items.json";
-        private static readonly string HistoryPath = "tracked_history.json";
+        private static readonly string HistoryPath = "item_history.json";
         private static readonly string ZenHistoryPath = "zen_history.json";
 
         public static void RegistrarContagemDiaria()
@@ -36,8 +26,8 @@ namespace ItemInterpreter.Logic
 
             var trackedItems = JsonSerializer.Deserialize<List<TrackedItem>>(File.ReadAllText(ConfigPath)) ?? new();
             var historico = File.Exists(HistoryPath)
-                ? JsonSerializer.Deserialize<List<ItemTrackingLog>>(File.ReadAllText(HistoryPath)) ?? new()
-                : new List<ItemTrackingLog>();
+                ? JsonSerializer.Deserialize<List<ItemSnapshot>>(File.ReadAllText(HistoryPath)) ?? new()
+                : new List<ItemSnapshot>();
 
             var hoje = DateTime.Today;
 
@@ -45,20 +35,20 @@ namespace ItemInterpreter.Logic
             conn.Open();
 
             // 🔹 Gravar histórico de itens apenas se ainda não existir para o dia
-            if (!historico.Any(h => h.Date == hoje))
+            if (!historico.Any(h => h.Timestamp.Date == hoje))
             {
                 foreach (var item in trackedItems)
                 {
                     int warehouseCount = ContarItem(conn, "Warehouse", "Items", item.Section, item.Index);
                     int inventoryCount = ContarItem(conn, "Character", "Inventory", item.Section, item.Index);
 
-                    historico.Add(new ItemTrackingLog
+                    historico.Add(new ItemSnapshot
                     {
                         Section = item.Section,
                         Index = item.Index,
-                        Date = hoje,
-                        Warehouse = warehouseCount,
-                        Inventory = inventoryCount,
+                        Timestamp = hoje,
+                        WarehouseCount = warehouseCount,
+                        InventoryCount = inventoryCount,
                         ItemName = ObterNomeDoItem(item.Section, item.Index)
                     });
                 }

--- a/ItemInterpreter/Logic/DashboardAuditLogger.cs
+++ b/ItemInterpreter/Logic/DashboardAuditLogger.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace ItemInterpreter.Logic
+{
+    public class DashboardAuditLogger
+    {
+        private readonly string _auditPath;
+
+        public DashboardAuditLogger(string? auditPath = null)
+        {
+            _auditPath = auditPath ?? "dashboard_audit.json";
+        }
+
+        public void AppendEntry(SyncAuditEntry entry)
+        {
+            var entries = ReadEntries();
+            entries.Add(entry);
+
+            var json = JsonSerializer.Serialize(entries, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(_auditPath, json);
+        }
+
+        public List<SyncAuditEntry> ReadEntries()
+        {
+            if (!File.Exists(_auditPath))
+            {
+                return new List<SyncAuditEntry>();
+            }
+
+            try
+            {
+                var json = File.ReadAllText(_auditPath);
+                return JsonSerializer.Deserialize<List<SyncAuditEntry>>(json) ?? new List<SyncAuditEntry>();
+            }
+            catch
+            {
+                return new List<SyncAuditEntry>();
+            }
+        }
+    }
+
+    public class SyncAuditEntry
+    {
+        public DateTime Timestamp { get; set; }
+        public long TotalZen { get; set; }
+        public List<SyncAuditItemDetail> Items { get; set; } = new();
+        public List<string> Alerts { get; set; } = new();
+    }
+
+    public class SyncAuditItemDetail
+    {
+        public string ItemName { get; set; } = string.Empty;
+        public int Section { get; set; }
+        public int Index { get; set; }
+        public int InventoryCount { get; set; }
+        public int WarehouseCount { get; set; }
+        public int TotalCount { get; set; }
+    }
+}

--- a/ItemInterpreter/Logic/ItemHistoryService.cs
+++ b/ItemInterpreter/Logic/ItemHistoryService.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using ItemInterpreter.Data;
+
+namespace ItemInterpreter.Logic
+{
+    public class ItemHistoryService
+    {
+        private readonly string _historyPath;
+        private readonly int _maxEntriesPerItem;
+
+        public ItemHistoryService(string? historyPath = null, int maxEntriesPerItem = 1000)
+        {
+            _historyPath = historyPath ?? "item_history.json";
+            _maxEntriesPerItem = maxEntriesPerItem;
+        }
+
+        public List<ItemSnapshot> ReadHistory()
+        {
+            if (!File.Exists(_historyPath))
+            {
+                return new List<ItemSnapshot>();
+            }
+
+            try
+            {
+                var json = File.ReadAllText(_historyPath);
+                return JsonSerializer.Deserialize<List<ItemSnapshot>>(json) ?? new List<ItemSnapshot>();
+            }
+            catch
+            {
+                return new List<ItemSnapshot>();
+            }
+        }
+
+        public void AppendSnapshots(IEnumerable<ItemSnapshot> snapshots)
+        {
+            var existing = ReadHistory();
+            existing.AddRange(snapshots);
+
+            var trimmed = existing
+                .GroupBy(s => (s.Section, s.Index))
+                .SelectMany(g => g
+                    .OrderByDescending(s => s.Timestamp)
+                    .Take(_maxEntriesPerItem))
+                .OrderBy(s => s.Timestamp)
+                .ToList();
+
+            var json = JsonSerializer.Serialize(trimmed, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(_historyPath, json);
+        }
+    }
+}

--- a/ItemInterpreter/Logic/ItemMarketAgent.cs
+++ b/ItemInterpreter/Logic/ItemMarketAgent.cs
@@ -37,23 +37,23 @@ namespace ItemInterpreter.Logic
             };
 
             var tracked = JsonSerializer.Deserialize<List<TrackedItem>>(File.ReadAllText("tracked_items.json")) ?? new();
-            var historico = new List<ItemTrackingLog>();
+            var historico = new List<ItemSnapshot>();
 
             foreach (var item in tracked)
             {
-                historico.Add(new ItemTrackingLog
+                historico.Add(new ItemSnapshot
                 {
-                    ItemName = $"ITEMGET({item.Section},{item.Index})",
                     Section = item.Section,
                     Index = item.Index,
-                    Date = DateTime.Now,
-                    Warehouse = warehouse.GetValueOrDefault((item.Section, item.Index)),
-                    Inventory = inventory.GetValueOrDefault((item.Section, item.Index)),
+                    ItemName = string.IsNullOrWhiteSpace(item.ItemName) ? $"ITEMGET({item.Section},{item.Index})" : item.ItemName,
+                    Timestamp = DateTime.Now,
+                    WarehouseCount = warehouse.GetValueOrDefault((item.Section, item.Index)),
+                    InventoryCount = inventory.GetValueOrDefault((item.Section, item.Index)),
                 });
             }
 
             Salvar("zen_history.json", dataZen);
-            Salvar("tracked_history.json", historico);
+            Salvar("item_history.json", historico);
         }
 
         private void Salvar<T>(string path, T entrada)

--- a/ItemInterpreter/UI/Charts/ItemCountChart.xaml
+++ b/ItemInterpreter/UI/Charts/ItemCountChart.xaml
@@ -1,9 +1,9 @@
-﻿<Window x:Class="ItemInterpreter.UI.Charts.ItemCountChart"
+<Window x:Class="ItemInterpreter.UI.Charts.ItemCountChart"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:oxy="http://oxyplot.org/wpf"
         Title="Gráfico de Itens Rastreáveis"
-        Height="650" Width="1000"
+        Height="650" Width="1100"
         Background="#1E1E1E" Foreground="White"
         WindowStartupLocation="CenterScreen">
 
@@ -13,23 +13,28 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <!-- Filtros -->
-        <StackPanel Orientation="Horizontal" Grid.Row="0" HorizontalAlignment="Left" >
-            <StackPanel>
-                <TextBlock Text="⏳ Período" FontSize="14" Margin="0 0 0 4"/>
-                <ComboBox x:Name="PeriodoComboBox" SelectionChanged="PeriodoComboBox_SelectionChanged"
-                          Width="180" Height="30" Background="#2D2D30" Foreground="White"/>
-            </StackPanel>
+        <Border Grid.Row="0" Background="#2D2D30" CornerRadius="10" Padding="12" Margin="0 0 0 12">
+            <Grid ColumnDefinitions="2*,2*,3*" ColumnSpacing="15">
+                <StackPanel>
+                    <TextBlock Text="⏳ Período" FontSize="14" Margin="0 0 0 4"/>
+                    <ComboBox x:Name="PeriodoComboBox" SelectionChanged="Filtro_Changed"
+                              Width="200" Height="32" Background="#1F1F1F" Foreground="White"/>
+                </StackPanel>
+                <StackPanel>
+                    <TextBlock Text="📦 Origem" FontSize="14" Margin="0 0 0 4"/>
+                    <ComboBox x:Name="OrigemComboBox" SelectionChanged="Filtro_Changed"
+                              Width="200" Height="32" Background="#1F1F1F" Foreground="White"/>
+                </StackPanel>
+                <StackPanel>
+                    <TextBlock Text="Itens" FontSize="14" Margin="0 0 0 4"/>
+                    <ListBox x:Name="ItemSelector" SelectionMode="Extended" Height="120"
+                             Background="#1F1F1F" Foreground="White" BorderThickness="0"
+                             SelectionChanged="Filtro_Changed"/>
+                </StackPanel>
+            </Grid>
+        </Border>
 
-            <StackPanel>
-                <TextBlock Text="📦 Origem" FontSize="14" Margin="0 0 0 4"/>
-                <ComboBox x:Name="OrigemComboBox" SelectionChanged="OrigemComboBox_SelectionChanged"
-                          Width="180" Height="30" Background="#2D2D30" Foreground="White"/>
-            </StackPanel>
-        </StackPanel>
-
-        <!-- Gráfico -->
-        <Border Grid.Row="1" Margin="0 20 0 0" BorderBrush="#444" BorderThickness="1" CornerRadius="10" Background="#2A2A2A">
+        <Border Grid.Row="1" BorderBrush="#444" BorderThickness="1" CornerRadius="10" Background="#2A2A2A">
             <oxy:PlotView x:Name="ItemChart"/>
         </Border>
     </Grid>

--- a/ItemInterpreter/UI/Configurador/ItemTrackerConfigGrouped.xaml
+++ b/ItemInterpreter/UI/Configurador/ItemTrackerConfigGrouped.xaml
@@ -17,39 +17,69 @@
         <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
             <TextBlock Text="🧩 Seção de Itens: " FontSize="16" VerticalAlignment="Center"/>
             <ComboBox x:Name="TypeComboBox"
-          SelectionChanged="TypeComboBox_SelectionChanged"
-          Width="300" Height="30"
-          Background="#2D2D30" Foreground="White" Margin="10 0 0 0"
-          DisplayMemberPath="Key"/>
-
+                      SelectionChanged="TypeComboBox_SelectionChanged"
+                      Width="320" Height="30"
+                      Background="#2D2D30" Foreground="White" Margin="10 0 0 0"
+                      DisplayMemberPath="Key"/>
         </StackPanel>
 
-        <!-- Lista de Itens -->
-        <ListBox x:Name="ItemListBox" Grid.Row="1" SelectionMode="Extended"
-         Background="#2D2D30" Foreground="White" BorderThickness="0"
-         ScrollViewer.VerticalScrollBarVisibility="Auto">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal" Margin="5">
-                        <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
-                        <TextBlock Text="  (Idx: " Foreground="Gray"/>
-                        <TextBlock Text="{Binding Index}" Foreground="Gray"/>
-                        <TextBlock Text=", Sec: " Foreground="Gray"/>
-                        <TextBlock Text="{Binding Section}" Foreground="Gray"/>
-                        <TextBlock Text=")" Foreground="Gray"/>
-                    </StackPanel>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
+        <Grid Grid.Row="1" ColumnDefinitions="2*,Auto,3*" ColumnSpacing="15">
+            <!-- Lista de Itens -->
+            <Border Background="#2D2D30" CornerRadius="8" Padding="10">
+                <DockPanel>
+                    <TextBlock Text="Itens disponíveis" FontWeight="Bold" FontSize="14" DockPanel.Dock="Top" Margin="0 0 0 8"/>
+                    <ListBox x:Name="ItemListBox" SelectionMode="Extended"
+                             Background="Transparent" Foreground="White" BorderThickness="0"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Vertical" Margin="5 2">
+                                    <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
+                                    <TextBlock Text="{Binding Path=Index, StringFormat=Idx: {0}}" Foreground="#BBBBBB" FontSize="12"/>
+                                    <TextBlock Text="{Binding Path=Section, StringFormat=Sec: {0}}" Foreground="#BBBBBB" FontSize="12"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </DockPanel>
+            </Border>
 
+            <!-- Botões de ação -->
+            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="10">
+                <Button Content="➕ Adicionar" Width="120" Click="AdicionarSelecionados_Click"/>
+                <Button Content="➖ Remover" Width="120" Click="RemoverSelecionados_Click"/>
+            </StackPanel>
 
+            <!-- Itens rastreados com metas -->
+            <Border Grid.Column="2" Background="#2D2D30" CornerRadius="8" Padding="10">
+                <DockPanel>
+                    <TextBlock Text="Itens rastreados" FontWeight="Bold" FontSize="14" DockPanel.Dock="Top" Margin="0 0 0 8"/>
+                    <DataGrid x:Name="TrackedItemsGrid"
+                              AutoGenerateColumns="False"
+                              Background="Transparent" Foreground="White"
+                              HeadersVisibility="Column"
+                              CanUserAddRows="False" CanUserDeleteRows="False"
+                              IsReadOnly="False">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Nome" Binding="{Binding ItemName}" IsReadOnly="True" Width="*"/>
+                            <DataGridTextColumn Header="Sec" Binding="{Binding Section}" IsReadOnly="True" Width="60"/>
+                            <DataGridTextColumn Header="Idx" Binding="{Binding Index}" IsReadOnly="True" Width="60"/>
+                            <DataGridTextColumn Header="Meta Min" Binding="{Binding MinimumTarget}" Width="90"/>
+                            <DataGridTextColumn Header="Meta Max" Binding="{Binding MaximumTarget}" Width="90"/>
+                            <DataGridTextColumn Header="Preço Compra" Binding="{Binding PurchasePrice}" Width="110"/>
+                            <DataGridTextColumn Header="Preço Venda" Binding="{Binding SalePrice}" Width="110"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </DockPanel>
+            </Border>
+        </Grid>
 
         <!-- Botões -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 15 0 0">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 15 0 0" Spacing="10">
             <Button Content="💾 Salvar" Click="Salvar_Click"
-                    Width="120" Height="35" Background="#4CAF50" Foreground="White"/>
+                    Width="140" Height="35" Background="#4CAF50" Foreground="White"/>
             <Button Content="❌ Cancelar" Click="Cancelar_Click"
-                    Width="120" Height="35" Background="#D32F2F" Foreground="White"/>
+                    Width="140" Height="35" Background="#D32F2F" Foreground="White"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/ItemInterpreter/UI/Dashboard/DashboardWindow.xaml
+++ b/ItemInterpreter/UI/Dashboard/DashboardWindow.xaml
@@ -12,29 +12,133 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Text="🎯 Itens Rastreando" FontSize="22" FontWeight="Bold" Margin="0 0 0 10"/>
+        <StackPanel Grid.Row="0" Orientation="Vertical" Margin="0 0 0 10">
+            <TextBlock Text="📊 Painel de Controle do Mercado" FontSize="24" FontWeight="Bold"/>
+            <TextBlock x:Name="LastUpdatedText" FontSize="12" Foreground="#AAAAAA" Margin="0 4 0 12"/>
 
-        <ListView x:Name="ItemListView" Grid.Row="1" Margin="0 10 0 10" Background="#2D2D30" BorderThickness="0">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Border BorderBrush="#444" BorderThickness="1" CornerRadius="10" Padding="10" Margin="5" Background="#2A2A2A">
-                        <StackPanel Orientation="Vertical">
-                            <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="16" />
-                            <TextBlock Text="📦 Inventário: " FontSize="14" Foreground="#AAA" />
-                            <TextBlock Text="{Binding InventoryCount}" FontSize="14" />
-                            <TextBlock Text="📦 Armazém: " FontSize="14" Foreground="#AAA" />
-                            <TextBlock Text="{Binding WarehouseCount}" FontSize="14" />
+            <UniformGrid Rows="1" Columns="4" HorizontalAlignment="Stretch" VerticalAlignment="Top" Height="90">
+            <Border Background="#2D2D30" CornerRadius="12" Margin="5" Padding="12">
+                <StackPanel>
+                    <TextBlock Text="Itens rastreados" FontSize="13" Foreground="#AAAAAA"/>
+                    <TextBlock x:Name="TotalTrackedText" FontSize="22" FontWeight="Bold"/>
+                </StackPanel>
+            </Border>
+            <Border Background="#2D2D30" CornerRadius="12" Margin="5" Padding="12">
+                <StackPanel>
+                    <TextBlock Text="Estoque total" FontSize="13" Foreground="#AAAAAA"/>
+                    <TextBlock x:Name="TotalInventoryText" FontSize="22" FontWeight="Bold"/>
+                </StackPanel>
+            </Border>
+            <Border Background="#2D2D30" CornerRadius="12" Margin="5" Padding="12">
+                <StackPanel>
+                    <TextBlock Text="Valor imobilizado" FontSize="13" Foreground="#AAAAAA"/>
+                    <TextBlock x:Name="TotalValueText" FontSize="22" FontWeight="Bold"/>
+                </StackPanel>
+            </Border>
+            <Border Background="#2D2D30" CornerRadius="12" Margin="5" Padding="12">
+                <StackPanel>
+                    <TextBlock Text="Zen em circulação" FontSize="13" Foreground="#AAAAAA"/>
+                    <TextBlock x:Name="TotalZenText" FontSize="22" FontWeight="Bold"/>
+                </StackPanel>
+            </Border>
+            </UniformGrid>
+        </StackPanel>
+
+        <Grid Grid.Row="1" Margin="0 0 0 10" ColumnDefinitions="3*,2*" ColumnSpacing="15">
+            <Border Background="#2D2D30" CornerRadius="12" Padding="10">
+                <ListView x:Name="ItemListView" Background="Transparent" BorderThickness="0" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <Border CornerRadius="8" Padding="10" Margin="0 6" Background="#2A2A2A" BorderBrush="{Binding StatusBrush}" BorderThickness="2">
+                                <StackPanel>
+                                    <DockPanel>
+                                        <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="16" Foreground="White"/>
+                                        <TextBlock Text="{Binding StatusMessage}" DockPanel.Dock="Right" FontSize="12" FontWeight="Bold" Foreground="{Binding StatusBrush}"/>
+                                    </DockPanel>
+                                    <UniformGrid Rows="2" Columns="3" Margin="0 6 0 0">
+                                        <StackPanel>
+                                            <TextBlock Text="Inventário" FontSize="12" Foreground="#CCCCCC"/>
+                                            <TextBlock Text="{Binding InventoryCount}" FontSize="14" FontWeight="SemiBold" Foreground="White"/>
+                                        </StackPanel>
+                                        <StackPanel>
+                                            <TextBlock Text="Armazém" FontSize="12" Foreground="#CCCCCC"/>
+                                            <TextBlock Text="{Binding WarehouseCount}" FontSize="14" FontWeight="SemiBold" Foreground="White"/>
+                                        </StackPanel>
+                                        <StackPanel>
+                                            <TextBlock Text="Total" FontSize="12" Foreground="#CCCCCC"/>
+                                            <TextBlock Text="{Binding TotalCount}" FontSize="14" FontWeight="SemiBold" Foreground="White"/>
+                                        </StackPanel>
+                                        <StackPanel>
+                                            <TextBlock Text="Meta Min" FontSize="12" Foreground="#CCCCCC"/>
+                                            <TextBlock Text="{Binding MinimumTargetDisplay}" FontSize="14" Foreground="White"/>
+                                        </StackPanel>
+                                        <StackPanel>
+                                            <TextBlock Text="Meta Max" FontSize="12" Foreground="#CCCCCC"/>
+                                            <TextBlock Text="{Binding MaximumTargetDisplay}" FontSize="14" Foreground="White"/>
+                                        </StackPanel>
+                                        <StackPanel>
+                                            <TextBlock Text="Margem" FontSize="12" Foreground="#CCCCCC"/>
+                                            <TextBlock Text="{Binding MarginDisplay}" FontSize="14" Foreground="White"/>
+                                        </StackPanel>
+                                    </UniformGrid>
+                                    <UniformGrid Rows="1" Columns="2" Margin="0 6 0 0">
+                                        <StackPanel>
+                                            <TextBlock Text="Custo total" FontSize="12" Foreground="#CCCCCC"/>
+                                            <TextBlock Text="{Binding TotalCostDisplay}" FontSize="14" FontWeight="SemiBold" Foreground="White"/>
+                                        </StackPanel>
+                                        <StackPanel>
+                                            <TextBlock Text="Receita potencial" FontSize="12" Foreground="#CCCCCC"/>
+                                            <TextBlock Text="{Binding PotentialRevenueDisplay}" FontSize="14" FontWeight="SemiBold" Foreground="White"/>
+                                        </StackPanel>
+                                    </UniformGrid>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </Border>
+
+            <StackPanel Grid.Column="1" Spacing="10">
+                <Border Background="#2D2D30" CornerRadius="12" Padding="10">
+                    <StackPanel>
+                        <DockPanel>
+                            <TextBlock Text="⚠️ Alertas" FontSize="16" FontWeight="Bold"/>
+                            <Button Content="Limpar" DockPanel.Dock="Right" Click="LimparAlertas_Click" Width="80" Height="26" Margin="5 0 0 0"/>
+                        </DockPanel>
+                        <ListBox x:Name="AlertList" Background="Transparent" BorderThickness="0" Margin="0 10 0 0" Height="200"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Background="#2D2D30" CornerRadius="12" Padding="10">
+                    <StackPanel>
+                        <TextBlock Text="Atualização automática" FontSize="16" FontWeight="Bold" Margin="0 0 0 6"/>
+                        <StackPanel Orientation="Horizontal" Spacing="10">
+                            <CheckBox x:Name="AutoRefreshCheckBox" Content="Ativar" Checked="AutoRefreshCheckBox_Checked" Unchecked="AutoRefreshCheckBox_Unchecked"/>
+                            <ComboBox x:Name="AutoRefreshInterval" Width="150" SelectionChanged="AutoRefreshInterval_SelectionChanged">
+                                <ComboBoxItem Content="30 segundos" Tag="00:00:30"/>
+                                <ComboBoxItem Content="1 minuto" Tag="00:01:00"/>
+                                <ComboBoxItem Content="5 minutos" Tag="00:05:00"/>
+                                <ComboBoxItem Content="10 minutos" Tag="00:10:00"/>
+                            </ComboBox>
                         </StackPanel>
-                    </Border>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+                    </StackPanel>
+                </Border>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 10 0 0">
-            <Button Content="🔄 Atualizar" Click="Atualizar_Click" Width="120" Height="35" Background="#007ACC" Foreground="White"/>
-            <Button Content="➕ Configurar Itens" Click="OpenConfig_Click" Width="160" Height="35" Background="#4CAF50" Foreground="White"/>
-            <Button Content="❌ Remover Selecionado" Click="RemoverItem_Click" Width="180" Height="35" Background="#D32F2F" Foreground="White"/>
-            <Button Content="📊 Gráfico Zen" Click="AbrirGraficoZen_Click" Width="140" Height="35" Background="#FF9800" Foreground="White"/>
+                <Border Background="#2D2D30" CornerRadius="12" Padding="10">
+                    <StackPanel>
+                        <TextBlock Text="Histórico" FontSize="16" FontWeight="Bold" Margin="0 0 0 6"/>
+                        <Button Content="Abrir gráfico de itens" Click="AbrirGraficoItens_Click" Margin="0 5 0 0"/>
+                        <Button Content="Ver gráfico de Zen" Click="AbrirGraficoZen_Click" Margin="0 5 0 0"/>
+                        <Button Content="Exportar relatório CSV" Click="ExportarCsv_Click" Margin="0 5 0 0"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 10 0 0" Spacing="10">
+            <Button Content="🔄 Atualizar agora" Click="Atualizar_Click" Width="150" Height="38" Background="#007ACC" Foreground="White"/>
+            <Button Content="➕ Configurar Itens" Click="OpenConfig_Click" Width="170" Height="38" Background="#4CAF50" Foreground="White"/>
+            <Button Content="❌ Remover Selecionado" Click="RemoverItem_Click" Width="190" Height="38" Background="#D32F2F" Foreground="White"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/ItemInterpreter/UI/Dashboard/DashboardWindow.xaml.cs
+++ b/ItemInterpreter/UI/Dashboard/DashboardWindow.xaml.cs
@@ -1,13 +1,21 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Threading;
 using ItemInterpreter.Data;
 using ItemInterpreter.Loaders;
+using ItemInterpreter.Logic;
 using ItemInterpreter.UI.Charts;
 using ItemInterpreter.UI.Configurador;
-using ItemInterpreter.Logic;
+using Microsoft.Win32;
 
 namespace ItemInterpreter.UI.Dashboard
 {
@@ -18,10 +26,58 @@ namespace ItemInterpreter.UI.Dashboard
             public string Name { get; set; } = string.Empty;
             public int InventoryCount { get; set; }
             public int WarehouseCount { get; set; }
+            public int Section { get; set; }
+            public int Index { get; set; }
+            public int? MinimumTarget { get; set; }
+            public int? MaximumTarget { get; set; }
+            public decimal? PurchasePrice { get; set; }
+            public decimal? SalePrice { get; set; }
+            public InventoryStatus Status { get; set; }
+            public Brush StatusBrush { get; set; } = Brushes.Gray;
+            public string StatusMessage { get; set; } = string.Empty;
+
+            public int TotalCount => InventoryCount + WarehouseCount;
+            public string MinimumTargetDisplay => MinimumTarget?.ToString() ?? "—";
+            public string MaximumTargetDisplay => MaximumTarget?.ToString() ?? "—";
+
+            public string MarginDisplay
+            {
+                get
+                {
+                    if (PurchasePrice.HasValue && SalePrice.HasValue && PurchasePrice.Value > 0)
+                    {
+                        var margin = (SalePrice.Value - PurchasePrice.Value) / PurchasePrice.Value * 100m;
+                        return $"{margin:F1}%";
+                    }
+
+                    return "—";
+                }
+            }
+
+            public string TotalCostDisplay => PurchasePrice.HasValue ? FormatCurrency(PurchasePrice.Value * TotalCount) : "—";
+            public string PotentialRevenueDisplay => SalePrice.HasValue ? FormatCurrency(SalePrice.Value * TotalCount) : "—";
+
+            private static string FormatCurrency(decimal value)
+            {
+                return value.ToString("C", CultureInfo.GetCultureInfo("pt-BR"));
+            }
+        }
+
+        public enum InventoryStatus
+        {
+            Healthy,
+            BelowMinimum,
+            AboveMaximum
         }
 
         private readonly string _configPath = "tracked_items.json";
         private readonly string _connectionString = "Data Source=localhost;Initial Catalog=MuOnline;Integrated Security=True;TrustServerCertificate=True;";
+
+        private readonly ItemHistoryService _historyService = new();
+        private readonly DashboardAuditLogger _auditLogger = new();
+        private readonly DispatcherTimer _autoRefreshTimer = new();
+        private readonly ObservableCollection<string> _alerts = new();
+        private readonly HashSet<string> _alertRegistry = new();
 
         private List<ItemDefinition> _itemDatabase = ItemXmlLoader.Load("IGC_ItemList.xml");
         private List<TrackedItem> _trackedItems = new();
@@ -29,8 +85,15 @@ namespace ItemInterpreter.UI.Dashboard
         public DashboardWindow()
         {
             InitializeComponent();
+            AlertList.ItemsSource = _alerts;
+            AutoRefreshInterval.SelectedIndex = 2; // 5 minutos
+            AutoRefreshCheckBox.IsChecked = true;
+
+            _autoRefreshTimer.Tick += AutoRefreshTimer_Tick;
+
             LoadTrackedItems();
             RefreshData();
+            ConfigureAutoRefreshTimer();
         }
 
         private void LoadTrackedItems()
@@ -39,29 +102,116 @@ namespace ItemInterpreter.UI.Dashboard
             {
                 var json = File.ReadAllText(_configPath);
                 _trackedItems = JsonSerializer.Deserialize<List<TrackedItem>>(json) ?? new();
+
+                foreach (var item in _trackedItems)
+                {
+                    var definition = _itemDatabase.FirstOrDefault(d => d.Section == item.Section && d.Index == item.Index);
+                    if (definition != null)
+                    {
+                        item.ItemName = definition.Name;
+                    }
+                }
             }
         }
 
         private void RefreshData()
         {
+            var now = DateTime.Now;
             var dbReader = new DatabaseItemReader(_connectionString);
             var inventoryCounts = dbReader.ReadInventoryCounts();
             var warehouseCounts = dbReader.ReadWarehouseCounts();
+            var totalZen = dbReader.ReadTotalZenInventory() + dbReader.ReadTotalZenWarehouse();
 
-            var displayList = _trackedItems.Select(pair =>
+            var displayList = new List<TrackedItemDisplay>();
+            var newAlerts = new List<string>();
+
+            decimal totalCost = 0m;
+            decimal totalPotentialRevenue = 0m;
+            int totalStock = 0;
+
+            foreach (var pair in _trackedItems)
             {
                 var item = _itemDatabase.FirstOrDefault(i => i.Section == pair.Section && i.Index == pair.Index);
                 var key = (pair.Section, pair.Index);
-                return new TrackedItemDisplay
-                {
-                    Name = item?.Name ?? $"ITEMGET({pair.Section},{pair.Index})",
-                    InventoryCount = inventoryCounts.TryGetValue(key, out var inv) ? inv : 0,
-                    WarehouseCount = warehouseCounts.TryGetValue(key, out var wh) ? wh : 0
-                };
-            }).ToList();
+                var inventory = inventoryCounts.TryGetValue(key, out var inv) ? inv : 0;
+                var warehouse = warehouseCounts.TryGetValue(key, out var wh) ? wh : 0;
+                var total = inventory + warehouse;
 
+                var status = InventoryStatus.Healthy;
+                string statusMessage = "Estoque equilibrado";
+                Brush statusBrush = new SolidColorBrush(Color.FromRgb(102, 187, 106));
+
+                if (pair.MinimumTarget.HasValue && total < pair.MinimumTarget.Value)
+                {
+                    status = InventoryStatus.BelowMinimum;
+                    statusMessage = "Abaixo da meta";
+                    statusBrush = new SolidColorBrush(Color.FromRgb(244, 67, 54));
+                }
+                else if (pair.MaximumTarget.HasValue && total > pair.MaximumTarget.Value)
+                {
+                    status = InventoryStatus.AboveMaximum;
+                    statusMessage = "Acima do limite";
+                    statusBrush = new SolidColorBrush(Color.FromRgb(255, 183, 77));
+                }
+
+                var display = new TrackedItemDisplay
+                {
+                    Name = item?.Name ?? pair.ItemName ?? $"ITEMGET({pair.Section},{pair.Index})",
+                    InventoryCount = inventory,
+                    WarehouseCount = warehouse,
+                    Section = pair.Section,
+                    Index = pair.Index,
+                    MinimumTarget = pair.MinimumTarget,
+                    MaximumTarget = pair.MaximumTarget,
+                    PurchasePrice = pair.PurchasePrice,
+                    SalePrice = pair.SalePrice,
+                    Status = status,
+                    StatusMessage = statusMessage,
+                    StatusBrush = statusBrush
+                };
+
+                displayList.Add(display);
+
+                if (pair.PurchasePrice.HasValue)
+                {
+                    totalCost += pair.PurchasePrice.Value * display.TotalCount;
+                }
+
+                if (pair.SalePrice.HasValue)
+                {
+                    totalPotentialRevenue += pair.SalePrice.Value * display.TotalCount;
+                }
+
+                totalStock += display.TotalCount;
+
+                if (status != InventoryStatus.Healthy)
+                {
+                    string alertMessage = $"{display.Name}: {statusMessage} (total {display.TotalCount})";
+                    newAlerts.Add(alertMessage);
+                }
+            }
 
             ItemListView.ItemsSource = displayList;
+
+            LastUpdatedText.Text = $"Última atualização: {now:dd/MM/yyyy HH:mm:ss}";
+            TotalTrackedText.Text = displayList.Count.ToString();
+            TotalInventoryText.Text = totalStock.ToString();
+            TotalValueText.Text = totalCost > 0 ? totalCost.ToString("C", CultureInfo.GetCultureInfo("pt-BR")) : "—";
+            if (totalPotentialRevenue > 0 && totalCost > 0)
+            {
+                var ganho = totalPotentialRevenue - totalCost;
+                var percentual = totalCost > 0 ? ganho / totalCost * 100m : 0;
+                TotalValueText.ToolTip = $"Receita potencial: {totalPotentialRevenue.ToString("C", CultureInfo.GetCultureInfo("pt-BR"))} (Δ {ganho.ToString("C", CultureInfo.GetCultureInfo("pt-BR"))}, {percentual:F1}%)";
+            }
+            else
+            {
+                TotalValueText.ToolTip = null;
+            }
+            TotalZenText.Text = totalZen.ToString("N0", CultureInfo.GetCultureInfo("pt-BR"));
+
+            AppendSnapshots(displayList, now);
+            RegisterAlerts(newAlerts);
+            LogSync(displayList, totalZen, newAlerts, now);
         }
 
         private void Atualizar_Click(object sender, RoutedEventArgs e)
@@ -85,32 +235,175 @@ namespace ItemInterpreter.UI.Dashboard
         {
             if (ItemListView.SelectedItem is TrackedItemDisplay selectedDisplay)
             {
-                // Converte o nome ITEMGET(x, y) ou procura pelo nome no banco de dados
-                var match = _itemDatabase.FirstOrDefault(item => item.Name == selectedDisplay.Name);
-                if (match != null)
-                {
-                    // Remove da lista de itens rastreados
-                    _trackedItems = _trackedItems
-                        .Where(t => !(t.Section == match.Section && t.Index == match.Index))
-                        .ToList();
+                _trackedItems = _trackedItems
+                    .Where(t => !(t.Section == selectedDisplay.Section && t.Index == selectedDisplay.Index))
+                    .ToList();
 
-                    // Salva o arquivo atualizado
-                    var json = JsonSerializer.Serialize(_trackedItems);
-                    File.WriteAllText(_configPath, json);
+                var json = JsonSerializer.Serialize(_trackedItems);
+                File.WriteAllText(_configPath, json);
 
-                    // Atualiza visualmente
-                    RefreshData();
-                }
-                else
-                {
-                    MessageBox.Show("Não foi possível identificar o item para remoção.");
-                }
+                RefreshData();
             }
         }
 
         private void AbrirGraficoZen_Click(object sender, RoutedEventArgs e)
         {
             new ZenChart().Show();
+        }
+
+        private void AbrirGraficoItens_Click(object sender, RoutedEventArgs e)
+        {
+            new ItemCountChart().Show();
+        }
+
+        private void ExportarCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (ItemListView.ItemsSource is not IEnumerable<TrackedItemDisplay> items)
+                return;
+
+            var dialog = new SaveFileDialog
+            {
+                Filter = "Arquivo CSV (*.csv)|*.csv",
+                FileName = $"dashboard_itens_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
+            };
+
+            if (dialog.ShowDialog() != true)
+                return;
+
+            var builder = new StringBuilder();
+            builder.AppendLine("Item;Sec;Idx;Inventario;Armazem;Total;MetaMin;MetaMax;PrecoCompra;PrecoVenda;CustoTotal;ReceitaPotencial;Margem");
+
+            foreach (var item in items)
+            {
+                builder.AppendLine(string.Join(';', new[]
+                {
+                    EscapeCsv(item.Name),
+                    item.Section.ToString(),
+                    item.Index.ToString(),
+                    item.InventoryCount.ToString(),
+                    item.WarehouseCount.ToString(),
+                    item.TotalCount.ToString(),
+                    item.MinimumTarget?.ToString() ?? string.Empty,
+                    item.MaximumTarget?.ToString() ?? string.Empty,
+                    item.PurchasePrice?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+                    item.SalePrice?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+                    ExtractNumeric(item.TotalCostDisplay),
+                    ExtractNumeric(item.PotentialRevenueDisplay),
+                    item.MarginDisplay
+                }));
+            }
+
+            File.WriteAllText(dialog.FileName, builder.ToString(), Encoding.UTF8);
+            MessageBox.Show("Relatório exportado com sucesso!", "Exportação", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private static string EscapeCsv(string value)
+        {
+            if (value.Contains(';'))
+            {
+                return '"' + value.Replace("\"", "\"\"") + '"';
+            }
+
+            return value;
+        }
+
+        private static string ExtractNumeric(string formattedValue)
+        {
+            if (string.IsNullOrWhiteSpace(formattedValue) || formattedValue == "—")
+                return string.Empty;
+
+            var digits = formattedValue.Where(c => char.IsDigit(c) || c == ',' || c == '.').ToArray();
+            return new string(digits);
+        }
+
+        private void AppendSnapshots(IEnumerable<TrackedItemDisplay> items, DateTime timestamp)
+        {
+            var snapshots = items.Select(i => new ItemSnapshot
+            {
+                Timestamp = timestamp,
+                Section = i.Section,
+                Index = i.Index,
+                ItemName = i.Name,
+                InventoryCount = i.InventoryCount,
+                WarehouseCount = i.WarehouseCount
+            }).ToList();
+
+            if (snapshots.Count == 0)
+                return;
+
+            _historyService.AppendSnapshots(snapshots);
+        }
+
+        private void RegisterAlerts(IEnumerable<string> alerts)
+        {
+            foreach (var alert in alerts)
+            {
+                if (_alertRegistry.Add(alert))
+                {
+                    _alerts.Add($"[{DateTime.Now:HH:mm}] {alert}");
+                }
+            }
+        }
+
+        private void LogSync(IEnumerable<TrackedItemDisplay> items, long totalZen, IEnumerable<string> alerts, DateTime timestamp)
+        {
+            var entry = new SyncAuditEntry
+            {
+                Timestamp = timestamp,
+                TotalZen = totalZen,
+                Items = items.Select(i => new SyncAuditItemDetail
+                {
+                    ItemName = i.Name,
+                    Section = i.Section,
+                    Index = i.Index,
+                    InventoryCount = i.InventoryCount,
+                    WarehouseCount = i.WarehouseCount,
+                    TotalCount = i.TotalCount
+                }).ToList(),
+                Alerts = alerts.ToList()
+            };
+
+            _auditLogger.AppendEntry(entry);
+        }
+
+        private void AutoRefreshTimer_Tick(object? sender, EventArgs e)
+        {
+            LoadTrackedItems();
+            RefreshData();
+        }
+
+        private void AutoRefreshCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            ConfigureAutoRefreshTimer();
+        }
+
+        private void AutoRefreshCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            _autoRefreshTimer.Stop();
+        }
+
+        private void AutoRefreshInterval_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ConfigureAutoRefreshTimer();
+        }
+
+        private void ConfigureAutoRefreshTimer()
+        {
+            if (AutoRefreshCheckBox.IsChecked != true)
+                return;
+
+            if (AutoRefreshInterval.SelectedItem is ComboBoxItem combo && combo.Tag is string tag && TimeSpan.TryParse(tag, out var interval))
+            {
+                _autoRefreshTimer.Stop();
+                _autoRefreshTimer.Interval = interval;
+                _autoRefreshTimer.Start();
+            }
+        }
+
+        private void LimparAlertas_Click(object sender, RoutedEventArgs e)
+        {
+            _alerts.Clear();
+            _alertRegistry.Clear();
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend tracked item data with targets and pricing metadata and provide configuration UI to edit these fields
- redesign the dashboard with KPI widgets, automatic refresh, alerting, CSV export and richer item cards highlighting stock status
- persist inventory snapshots and audit entries, reuse them in the refreshed item history chart and supporting background jobs

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cacb8807248332b9051dcaa632032b